### PR TITLE
[Post-005] Exposing method to remove all info on the device

### DIFF
--- a/app/src/main/java/com/arubianoch/posttest/data/repository/PostRepository.kt
+++ b/app/src/main/java/com/arubianoch/posttest/data/repository/PostRepository.kt
@@ -25,4 +25,6 @@ interface PostRepository {
     suspend fun getComments(postId: String): LiveData<List<Comment>>
 
     suspend fun getUser(postId: String): LiveData<User>
+
+    suspend fun deleteAllInfo()
 }

--- a/app/src/main/java/com/arubianoch/posttest/data/repository/PostRepositoryImpl.kt
+++ b/app/src/main/java/com/arubianoch/posttest/data/repository/PostRepositoryImpl.kt
@@ -133,4 +133,12 @@ class PostRepositoryImpl(
             userDao.upsert(user)
         }
     }
+
+    override suspend fun deleteAllInfo() {
+        GlobalScope.launch(Dispatchers.IO) {
+            userDao.deleteAllUsers()
+            commentDao.deleteAllComments()
+            postDao.deleteAllPost()
+        }
+    }
 }


### PR DESCRIPTION
# Description
The app is necessary to remove all info saved on local storage; that why this PR is; now, repository expose a method that remove all info saved on local storage.

# Changes
* Added method that clean and remove all info saved on our local storage.

# Evidence
N/A